### PR TITLE
New features + documentation bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ var i18next = require('i18next');
 var middleware = require('i18next-express-middleware');
 
 i18next
-  .use(middleware.LngDetector)
+  .use(middleware.LanguageDetector)
   .init({
     detection: options
   });
@@ -112,7 +112,7 @@ on construction:
 
 ```js
 var middleware = require('i18next-express-middleware');
-var lngDetector = new middleware.LngDetector(null, options);
+var lngDetector = new middleware.LanguageDetector(null, options);
 ```
 
 via calling init:
@@ -120,7 +120,7 @@ via calling init:
 ```js
 var middleware = require('i18next-express-middleware');
 
-var lngDetector = new middleware.LngDetector();
+var lngDetector = new middleware.LanguageDetector();
 lngDetector.init(options);
 ```
 
@@ -153,7 +153,7 @@ module.exports {
 var i18next = require('i18next');
 var middleware = require('i18next-express-middleware');
 
-var lngDetector = new middleware.LngDetector();
+var lngDetector = new middleware.LanguageDetector();
 lngDetector.addDetector(myDetector);
 
 i18next

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,6 +72,7 @@ function handle(i18next) {
       res.locals.exists = exists;
       res.locals.i18n = i18n;
       res.locals.language = lng;
+      res.locals.languageDir = i18next.dir(lng);
     }
 
     if (i18next.services.languageDetector) i18next.services.languageDetector.cacheUserLanguage(req, res, lng);

--- a/lib/languageLookups/path.js
+++ b/lib/languageLookups/path.js
@@ -11,6 +11,10 @@ exports['default'] = {
 
     if (options.lookupFromPathIndex !== undefined && typeof req !== 'undefined') {
       var parts = req.originalUrl.split('/');
+      if (parts[0] === '') {
+        // Handle paths that start with a slash, i.e., '/foo' -> ['', 'foo']
+        parts.shift();
+      }
 
       if (parts.length > options.lookupFromPathIndex) {
         found = parts[options.lookupFromPathIndex];

--- a/src/index.js
+++ b/src/index.js
@@ -48,6 +48,7 @@ export function handle(i18next, options = {}) {
       res.locals.exists = exists;
       res.locals.i18n = i18n;
       res.locals.language = lng;
+      res.locals.languageDir = i18next.dir(lng);
     }
 
     if (i18next.services.languageDetector) i18next.services.languageDetector.cacheUserLanguage(req, res, lng);

--- a/src/languageLookups/path.js
+++ b/src/languageLookups/path.js
@@ -6,6 +6,9 @@ export default {
 
     if (options.lookupFromPathIndex !== undefined && typeof req !== 'undefined') {
       let parts = req.originalUrl.split('/');
+      if(parts[0] === '') { // Handle paths that start with a slash, i.e., '/foo' -> ['', 'foo']
+        parts.shift();
+      }
 
       if (parts.length > options.lookupFromPathIndex) {
         found = parts[options.lookupFromPathIndex];


### PR DESCRIPTION
Hi, a few things for your consideration!

First there is a small bug in the documentation where `LanguageDetector` was referred to as `LngDetector`.
The commit fixes the index of a path element in the case the path begins in a `/`. I think it's more natural to think of the first element after the `/` as index zero.
Then I added a `languageDir` to the locals, to make it easier to embed in the `html` tag (`<html lang="en" dir="ltr">`)
The last one is the option to remove the language element from the url, which can be useful so as not to have to write the language parameter into the router for each page, for example, `/en/foo -> /foo`