### PR TITLE
Fix path detection can crash app (if req.originalUrl is not set)

### DIFF
--- a/src/languageLookups/path.js
+++ b/src/languageLookups/path.js
@@ -8,11 +8,11 @@ export default {
       return found;
     }
 
-    if (options.lookupPath !== undefined) {
+    if (options.lookupPath !== undefined && req.params) {
       found = req.params[options.lookupPath];
     }
 
-    if (!found && options.lookupFromPathIndex !== undefined) {
+    if (!found && typeof options.lookupFromPathIndex === 'number' && req.originalUrl) {
       let path = req.originalUrl.split('?')[0];
       let parts = path.split('/');
       if (parts[0] === '') { // Handle paths that start with a slash, i.e., '/foo' -> ['', 'foo']


### PR DESCRIPTION
hi there, 

## Background

the following line crashes if `req.originalUrl` is not set (it is technically possible even though unexpected in the context of `express`!):

https://github.com/i18next/i18next-express-middleware/blob/095a5a926a2ad9e6dcaebc2a22cbb42780b4003e/src/languageLookups/path.js#L16

having encountered that I decided to try and set the `lookupFromPathIndex` option to `undefined`, but that is not possible due to the default value being `0` in combination with how the option defaults are applied (`undefined` values are always overwritten) i.e.


setting of option defaults happens here: https://github.com/i18next/i18next-express-middleware/blob/095a5a926a2ad9e6dcaebc2a22cbb42780b4003e/src/LanguageDetector.js#L33

logic for merging options with defaults is here: https://github.com/i18next/i18next-express-middleware
/blob/095a5a926a2ad9e6dcaebc2a22cbb42780b4003e/src/utils.js#L26

## "Solution"

this PR :-) the changes are as follows:

1. change the type check of `lookupFromPathIndex` so the "by index" lookup is only attempted if the value is a number - this allows people to turn it off by setting the option to `false`
2. add a check for existence of `req.originalUrl` - to avoid potential TypeErrors  
3. add a check for existence of `req.params` - to avoid potential TypeErrors  (because I'm paranoid)

number 3 in the list is not directly related to the issue I had but I figured "better safe than sorry"
