### PR TITLE
Guard against non-string detections

### DIFF
--- a/src/LanguageDetector.js
+++ b/src/LanguageDetector.js
@@ -54,10 +54,10 @@ class LanguageDetector {
 
       let detections = this.detectors[detectorName].lookup(req, res, this.options);
       if(!detections) return;
-      if (typeof detections === 'string') detections = [detections];
+      if (!Array.isArray(detections)) detections = [detections];
 
       detections.forEach(lng => {
-        if (found) return;
+        if (found || typeof lng !== 'string') return;
 
         let cleanedLng = this.services.languageUtils.formatLanguageCode(lng);
 


### PR DESCRIPTION
This can happen with e.g. extended querystring parsing, where `lng` may end up being an object.