### PR TITLE
Check if the headers are sent before cookies set

### DIFF
--- a/src/languageLookups/cookie.js
+++ b/src/languageLookups/cookie.js
@@ -19,7 +19,7 @@ export default {
   },
 
   cacheUserLanguage(req, res, lng, options = {}) {
-    if (options.lookupCookie && req !== 'undefined') {
+    if (options.lookupCookie && req !== 'undefined' && !res._headerSent) {
       const cookies = new Cookies(req, res);
 
       let expirationDate = options.cookieExpirationDate;


### PR DESCRIPTION
Fix for issue #143. Just to prevent getting the error if the headers are sent, we do not try to set the cookies.