### PR TITLE
Fix cookie set crash on newer versions of express

### DIFF
--- a/src/languageLookups/cookie.js
+++ b/src/languageLookups/cookie.js
@@ -19,7 +19,7 @@ export default {
   },
 
   cacheUserLanguage(req, res, lng, options = {}) {
-    if (options.lookupCookie && req !== 'undefined' && !res._headerSent) {
+    if (options.lookupCookie && req !== 'undefined' && !(res._headerSent || res.headersSent)) {
       const cookies = new Cookies(req, res);
 
       let expirationDate = options.cookieExpirationDate;


### PR DESCRIPTION
In Express 4, this field is called `headersSent` so this module is throwing exceptions on that platform.

https://github.com/expressjs/express/blob/master/History.md#400--2014-04-09