### PR TITLE
fix: allow to pass secure to cookie options

### DIFF
--- a/src/languageLookups/cookie.js
+++ b/src/languageLookups/cookie.js
@@ -28,7 +28,15 @@ export default {
         expirationDate.setFullYear(expirationDate.getFullYear() + 1);
       }
 
-      cookies.set(options.lookupCookie, lng, { expires: expirationDate, domain: options.cookieDomain, httpOnly : false, overwrite: true });
+      const cookieOptions = {
+        expires: expirationDate,
+        domain: options.cookieDomain,
+        secure: options.cookieSecure,
+        httpOnly: false,
+        overwrite: true
+      };
+
+      cookies.set(options.lookupCookie, lng, cookieOptions);
     }
   }
 };


### PR DESCRIPTION
HI,
This one adds option to enable/disable `secure` param set for a cookie. 
Let me know what do you think about this change.