### PR TITLE
fix: check if cookieSecure param was specified

### DIFF
--- a/src/languageLookups/cookie.js
+++ b/src/languageLookups/cookie.js
@@ -31,10 +31,13 @@ export default {
       const cookieOptions = {
         expires: expirationDate,
         domain: options.cookieDomain,
-        secure: options.cookieSecure,
         httpOnly: false,
         overwrite: true
       };
+
+      if (options.hasOwnProperty('cookieSecure')) {
+        cookieOptions.secure = options.cookieSecure;
+      }
 
       cookies.set(options.lookupCookie, lng, cookieOptions);
     }


### PR DESCRIPTION
This one checks if `cookieSecure` param was specified in options and only if it was specified `secure` option is set on a cookie