### PR TITLE
Insensitive checking language-locale

### DIFF
--- a/src/languageLookups/header.js
+++ b/src/languageLookups/header.js
@@ -13,7 +13,7 @@ export default {
 
       if (acceptLanguage) {
         let lngs = [], i, m;
-        const rgx = /(([a-z]{2})-?([A-Z]{2})?)\s*;?\s*(q=([0-9.]+))?/g;
+        const rgx = /(([a-z]{2})-?([A-Z]{2})?)\s*;?\s*(q=([0-9.]+))?/gi;
         
         do {
           m = rgx.exec(acceptLanguage);


### PR DESCRIPTION
If locale code is not required to be uppercased, this commit fix bug when locale part is lowercased.

Fixes #171 