### PR TITLE
update LanguageDetector (fix type error since i18next v17.0.8)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -65,7 +65,9 @@ declare module 'i18next-express-middleware' {
     cacheUserLanguage?: (req: express.Request, res: express.Response, lng: string, options?: object) => void;
   }
 
-  export class LanguageDetector {
+  export class LanguageDetector implements i18next.Module {
+    type: "languageDetector";
+
     constructor(services: LanguageDetectorServices, options?: LanguageDetectorOptions, allOptions?: LanguageDetectorAllOptions);
     constructor(options?: LanguageDetectorOptions, allOptions?: LanguageDetectorAllOptions);
 


### PR DESCRIPTION
fixed type error:

```typescript
// error TS2345: Argument of type 'typeof LanguageDetector' is not assignable to parameter of type 'Module | ThirdPartyModule[] | Newable<ThirdPartyModule>[] | Newable<Module>'.
//   Type 'typeof LanguageDetector' is not assignable to type 'Newable<Module>'.
//     Property 'type' is missing in type 'LanguageDetector' but required in type 'Module'.
i18next.use(middleware.LanguageDetector);
```
