### PR TITLE
fix: TypeScript i18next import

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import * as express from 'express';
-import i18next from 'i18next';
+import * as i18next from 'i18next';
 
 declare global {
   namespace Express {


### PR DESCRIPTION
### Description

Fix TypeScript import of i18next in module declaration.

Since `i18next` does not provide a default export you have to import everything.
Setting the TypeScript compile option `esModuleInterop` is not a good practise and not an option for most projects out there.

---

### Error stack

```
node_modules/i18next-express-middleware/index.d.ts:2:8 - error TS1259: Module '"/Users/biedema/Documents/GitHub/work/moovel/mobility-benefits-core/node_modules/i18next/index"' can only be default-imported using the 'esModuleInterop' flag

2 import i18next from 'i18next';
         ~~~~~~~

  node_modules/i18next/index.d.ts:988:1
    988 export = i18next;
        ~~~~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.
```