### PR TITLE
Remove Express alias of res.setHeader

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ export function handle(i18next, options = {}) {
         }
 
         if (!res.headersSent) {
-          res.set('Content-Language', lng);
+          res.setHeader('Content-Language', lng);
         }
 
         req.languages = i18next.services.languageUtils.toResolveHierarchy(lng);
@@ -42,7 +42,7 @@ export function handle(i18next, options = {}) {
     // set locale
     req.language = req.locale = req.lng = lng;
     if (!res.headersSent) {
-      res.set('Content-Language', lng);
+      res.setHeader('Content-Language', lng);
     }
     req.languages = i18next.services.languageUtils.toResolveHierarchy(lng);
 


### PR DESCRIPTION
Following https://github.com/i18next/i18next-express-middleware/pull/191#issuecomment-561175320, it appears we can support non-Express use with [connect](https://www.npmjs.com/package/connect) and `https` by simply removing these two Express `res.set` calls. The `res.set` alias is identical to the vanilla `res.setHeader`.

This PR should be completely transparent to existing users, but will allow new users to opt out of Express.

It should be noted that due to lack of test coverage in this repo, there may indeed be other Express syntax problems that we have not discovered yet. Future bug reports by non-Express users may reveal these sorts of problems.

Also - we might at some point want to change the naming here to just `i18next-middleware`?