### PR TITLE
Update typings to export I18NextRequest instead of extending global express Request

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,21 +1,18 @@
 import * as express from 'express';
 import * as i18next from 'i18next';
 
-declare global {
-  namespace Express {
-    interface Request {
-      language: string;
-      languages: string[];
-      i18n:i18next.i18n;
-      t:i18next.TFunction
-    }
-  }
-}
 
 declare module 'i18next-express-middleware' {
   type I18next = i18next.i18n;
   type IgnoreRoutesFunction = (req: express.Request, res: express.Response, options: HandleOptions, i18next: I18next) => boolean;
   type App = express.Application | express.Router;
+
+  type I18NextRequest = i18next.Request & {
+    language: string;
+    languages: string[];
+    i18n:i18next.i18n;
+    t:i18next.TFunction;
+  }
 
   interface HandleOptions {
     ignoreRoutes?: string[] | IgnoreRoutesFunction;

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ declare module 'i18next-express-middleware' {
   type IgnoreRoutesFunction = (req: express.Request, res: express.Response, options: HandleOptions, i18next: I18next) => boolean;
   type App = express.Application | express.Router;
 
-  type I18NextRequest = i18next.Request & {
+  type I18NextRequest = express.Request & {
     language: string;
     languages: string[];
     i18n:i18next.i18n;


### PR DESCRIPTION
Hello @isaachinman , @jamuhl ,

As discussed within my previous PR, I created this one with updated typings.
https://github.com/i18next/i18next-express-middleware/pull/177

I had to replace in all my code req.t & req.language by (req as I18NextRequest).t and (req as I18NextRequest).language.

You may have people complain about this once merged but I guess this is the direction you would like to take for your typings.

Thanks,
Nicolas